### PR TITLE
Small improvements to README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ function BasicAutocomplete({items, onChange}) {
                     !value ||
                     i.toLowerCase().includes(value.toLowerCase()),
                 )
-                .map((value, index) => (
+                .map((item, index) => (
                   <div
-                    {...getItemProps({value, index})}
-                    key={value}
-                    style: {
+                    {...getItemProps({item, index})}
+                    key={item}
+                    style={{
                       backgroundColor:
                         highlightedIndex === index ? 'gray' : 'white',
                       fontWeight: selectedItem === item ? 'bold' : 'normal',
-                    }
+                    }}
                   >
                     {item}
                   </div>

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ function BasicAutocomplete({items, onChange}) {
                 )
                 .map((item, index) => (
                   <div
-                    {...getItemProps({item, index})}
+                    {...getItemProps({value: item, index})}
                     key={item}
                     style={{
                       backgroundColor:


### PR DESCRIPTION
This PR adds one small fix and one small improvement that I hope make the README code example easier for others to read.

- Syntax error: `style` was set on the div in a way that doesn't seem to be valid JSX (maybe there are some other Babel settings where this is valid?)
- I found the use of the variable name `value` in two places a bit confusing. At the top level, `value` refers to the string currently typed in the search field. Within the function provided to `map`, it instead refers to one of the items. I think renaming this second usage to `item` makes it clearer what the code is doing.